### PR TITLE
Create only a single style element

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "jasmine": "^2.4.1",
     "postcss-loader": "^0.8.2",
     "postcss-spiffing": "0.0.6",
+    "rimraf": "^2.5.2",
     "semistandard": "^7.0.5",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.14"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/spec/StyleExtHtmlWebpackPluginSpec.js
+++ b/spec/StyleExtHtmlWebpackPluginSpec.js
@@ -72,7 +72,7 @@ describe('StyleExtHtmlWebpackPlugin', function () {
           new StyleExtHtmlWebpackPlugin()
         ]
       },
-      [/(<style>[\s\S]*<\/style>){1}/],
+      [fs.readFileSync(path.join(__dirname, 'fixtures', 'exptected_one_stylesheet.html'))],
       done);
   });
 
@@ -93,7 +93,7 @@ describe('StyleExtHtmlWebpackPlugin', function () {
           new StyleExtHtmlWebpackPlugin()
         ]
       },
-      [/(<style>[\s\S]*<\/style>){2}/],
+      [fs.readFileSync(path.join(__dirname, 'fixtures', 'exptected_two_stylesheets.html'))],
       done);
   });
 

--- a/spec/fixtures/exptected_one_stylesheet.html
+++ b/spec/fixtures/exptected_one_stylesheet.html
@@ -1,0 +1,6 @@
+<head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  <style>body {
+  background: snow;
+}</style></head>

--- a/spec/fixtures/exptected_two_stylesheets.html
+++ b/spec/fixtures/exptected_two_stylesheets.html
@@ -1,0 +1,10 @@
+<head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  <style>body {
+  background: snow;
+}
+body {
+  color: grey;
+}
+</style></head>

--- a/spec/fixtures/stylesheet2.css
+++ b/spec/fixtures/stylesheet2.css
@@ -1,3 +1,3 @@
 body {
-  colour: grey;
+  color: grey;
 }


### PR DESCRIPTION
I was interested about the progress of your plugin so I dived into your source.

Unfortunately this pull request changes several parts at once so feel free to pick only some of them.

1) rimraf was missing so the tests failed
2) I replaced `this` in `addInlineCss` as it was confusing for a prototype function to use a different `this` (hope now it's clear that it is the compilation).
3) The injection now also works case insensitive e.g. `</HEAD>`.
4) To save some bytes only one `<style>` tag is added, this might be better for projects with a lot of small css files.
5) The tests now use an expected file.
6) Fixed a typo in your test css file