### PR TITLE
check against stored processed multiple files

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -24,7 +24,14 @@ const findGeneratedCssFile = (matchFn, compilation) => {
 };
 
 const validatePassedCssFilename = (cssFilename, compilation) => {
-  const matchFn = (filename) => filename === cssFilename;
+  let matchFn = (filename) => filename === cssFilename;
+
+  // what's done may never be did again
+  if(compilation.processed && compilation.processed.includes(cssFilename)) {
+    matchFn = (filename) => filename !== cssFilename && CSS_REGEX.test(filename);
+    deleteFileFromCompilation(cssFilename, compilation);
+  }
+
   return findGeneratedCssFile(matchFn, compilation);
 };
 
@@ -51,10 +58,14 @@ const handlePublicPath = (cssFilename, compilation) => {
   return cssFilename;
 };
 
-const replaceLinkTag = (stylePath, tags, replacementTag) => {
+const replaceLinkTag = (stylePath, tags, replacementTag, compilation) => {
   for (let index = 0; index < tags.length; index++) {
     if (isCssLinkTag(tags[index], stylePath)) {
       tags[index] = replacementTag;
+
+      // a successful replacement should store a reference of processed files
+      compilation.processed = compilation.processed || [];
+      compilation.processed.push(stylePath);
       debug(`${EVENT} replaced <link> with <style>`);
       return;
     }
@@ -103,7 +114,7 @@ class StyleExtHtmlWebpackPlugin {
               : identifyCssFilename(compilation);
             const replacementTag = generateReplacementStyleTag(cssFilename, compilation);
             const stylePath = handlePublicPath(cssFilename, compilation);
-            replaceLinkTag(stylePath, pluginArgs.head, replacementTag);
+            replaceLinkTag(stylePath, pluginArgs.head, replacementTag, compilation);
             callback(null, pluginArgs);
           } catch (err) {
             callback(err);


### PR DESCRIPTION
This is for a multiple-entry,each with their own js/css/templates, multiple-output scenario, as follows:

## example directory
.
+-- node_modules
+-- build
+-- dist
|   +-- page1.html
|   +-- page2.html
|   +-- page3.html
+-- src
|   +-- pages
|   |   +-- page1
|   |   |   +-- template.hbs
|   |   |   +-- index.js
|   |   |   +-- styles.css
|   |   +-- page2
|   |   |   +-- template.hbs
|   |   |   +-- index.js
|   |   |   +-- styles.css
|   |   +-- page3
+-- package.json
+-- webpack.config.js
+-- //etc...

## webpack.config.js
```
// ... some var setup above
let pageNames = ['page1','page2','page3'];

pageNames.forEach((pageName) => {
  entry[pageName] = `./src/pages/${pageName}`;
  extractTexts[pageName] = new ExtractTextPlugin('[name]-styles.css');

  loaders.push({
    test: /\.css$/,
    loader: extractTexts[pageName].extract('style', 'css'),
    include: [
      path.resolve(__dirname, 'src', 'pages', pageName)
    ]
  });

  plugins.push(new HtmlWebpackPlugin({
    chunks: [pageName],
    filename: `${pageName}.html`,
    template: `src/pages/${pageName}/template.hbs`
  }));

  plugins.push(extractTexts[pageName]);
});

plugins.push(new ScriptExtHtmlWebpackPlugin({
  inline: pageNames.map((pageName) => {
    return `${pageName}-scripts`;
  })
}));

plugins.push(new StyleExtHtmlWebpackPlugin());

```

Not sure if what I'm trying to do here is the best way, so any thoughts/suggestions would be greatly appreciated!