### PR TITLE
now supports multiple input/output and sass compilation

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -5,6 +5,7 @@ const debug = require('debug')('StyleExt');
 const PLUGIN = 'StyleExtHtmlWebpackPlugin';
 const EVENT = 'html-webpack-plugin-alter-asset-tags';
 const CSS_REGEX = /\.css$/;
+const PROCESSED_FILES = [];
 
 const error = msg => {
   const err = new Error(msg);
@@ -24,32 +25,18 @@ const findGeneratedCssFile = (matchFn, compilation) => {
 };
 
 const validatePassedCssFilename = (cssFilename, compilation) => {
-  let matchFn = (filename) => filename === cssFilename;
-
-  // what's done may never be did again
-  if (compilation.processed && compilation.processed.includes(cssFilename)) {
-    matchFn = (filename) => {
-      if(compilation.pluginCheck) {
-        return filename === compilation.pluginCheck && CSS_REGEX.test(filename);
-      } else {
-        return CSS_REGEX.test(filename);
-      }
+  const matchFn = (filename) => {
+    if (PROCESSED_FILES.includes(cssFilename)) {
+      return CSS_REGEX.test(filename) && filename !== cssFilename;
+    } else {
+      return filename === cssFilename;
     }
-    deleteFileFromCompilation(cssFilename, compilation);
-  }
-
+  };
   return findGeneratedCssFile(matchFn, compilation);
 };
 
 const identifyCssFilename = (compilation) => {
-  const matchFn = (filename) => {
-    if(!compilation.pluginCheck) {
-      return CSS_REGEX.test(filename)
-    } else {
-      return compilation.pluginCheck === filename;
-    }
-
-  };
+  const matchFn = (filename) => CSS_REGEX.test(filename);
   return findGeneratedCssFile(matchFn, compilation);
 };
 
@@ -71,15 +58,10 @@ const handlePublicPath = (cssFilename, compilation) => {
   return cssFilename;
 };
 
-const replaceLinkTag = (stylePath, tags, replacementTag, compilation) => {
+const replaceLinkTag = (stylePath, tags, replacementTag) => {
   for (let index = 0; index < tags.length; index++) {
     if (isCssLinkTag(tags[index], stylePath)) {
       tags[index] = replacementTag;
-
-      // a successful replacement should store a reference of processed files
-      compilation.processed = compilation.processed || [];
-      compilation.processed.push(stylePath);
-
       debug(`${EVENT} replaced <link> with <style>`);
       return;
     }
@@ -122,23 +104,23 @@ class StyleExtHtmlWebpackPlugin {
       // remove <link> and add <style>
       compiler.plugin('compilation', (compilation) => {
         compilation.plugin(EVENT, (pluginArgs, callback) => {
-          // the first match of a css file isn't always the correct one;
-          // here we stored what the pluginArgs is expecting to compare against later
-          compilation.pluginCheck = pluginArgs.head[0].attributes.href || null;
-          try {
-            // if the tagName isn't a link, do we need to do anything?
-            if(pluginArgs.head[0].tagName !== 'style') {
+          // really we only want to do things if it's a link tag...
+          if (pluginArgs && pluginArgs.head[0] && pluginArgs.head[0].tagName === 'link') {
+            try {
               cssFilename = (cssFilename)
                 ? validatePassedCssFilename(cssFilename, compilation)
                 : identifyCssFilename(compilation);
               const replacementTag = generateReplacementStyleTag(cssFilename, compilation);
               const stylePath = handlePublicPath(cssFilename, compilation);
-              replaceLinkTag(stylePath, pluginArgs.head, replacementTag, compilation);
+              replaceLinkTag(stylePath, pluginArgs.head, replacementTag);
+              // if we've replaced the link so far without failure, store a reference to the processed file
+              PROCESSED_FILES.push(cssFilename);
               callback(null, pluginArgs);
+            } catch (err) {
+              callback(err);
             }
-            
-          } catch (err) {
-            callback(err);
+          } else {
+            callback(null, pluginArgs);
           }
         });
       });

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -24,12 +24,32 @@ const findGeneratedCssFile = (matchFn, compilation) => {
 };
 
 const validatePassedCssFilename = (cssFilename, compilation) => {
-  const matchFn = (filename) => filename === cssFilename;
+  let matchFn = (filename) => filename === cssFilename;
+
+  // what's done may never be did again
+  if (compilation.processed && compilation.processed.includes(cssFilename)) {
+    matchFn = (filename) => {
+      if(compilation.pluginCheck) {
+        return filename === compilation.pluginCheck && CSS_REGEX.test(filename);
+      } else {
+        return CSS_REGEX.test(filename);
+      }
+    }
+    deleteFileFromCompilation(cssFilename, compilation);
+  }
+
   return findGeneratedCssFile(matchFn, compilation);
 };
 
 const identifyCssFilename = (compilation) => {
-  const matchFn = (filename) => CSS_REGEX.test(filename);
+  const matchFn = (filename) => {
+    if(!compilation.pluginCheck) {
+      return CSS_REGEX.test(filename)
+    } else {
+      return compilation.pluginCheck === filename;
+    }
+
+  };
   return findGeneratedCssFile(matchFn, compilation);
 };
 
@@ -51,10 +71,15 @@ const handlePublicPath = (cssFilename, compilation) => {
   return cssFilename;
 };
 
-const replaceLinkTag = (stylePath, tags, replacementTag) => {
+const replaceLinkTag = (stylePath, tags, replacementTag, compilation) => {
   for (let index = 0; index < tags.length; index++) {
     if (isCssLinkTag(tags[index], stylePath)) {
       tags[index] = replacementTag;
+
+      // a successful replacement should store a reference of processed files
+      compilation.processed = compilation.processed || [];
+      compilation.processed.push(stylePath);
+
       debug(`${EVENT} replaced <link> with <style>`);
       return;
     }
@@ -97,14 +122,21 @@ class StyleExtHtmlWebpackPlugin {
       // remove <link> and add <style>
       compiler.plugin('compilation', (compilation) => {
         compilation.plugin(EVENT, (pluginArgs, callback) => {
+          // the first match of a css file isn't always the correct one;
+          // here we stored what the pluginArgs is expecting to compare against later
+          compilation.pluginCheck = pluginArgs.head[0].attributes.href || null;
           try {
-            cssFilename = (cssFilename)
-              ? validatePassedCssFilename(cssFilename, compilation)
-              : identifyCssFilename(compilation);
-            const replacementTag = generateReplacementStyleTag(cssFilename, compilation);
-            const stylePath = handlePublicPath(cssFilename, compilation);
-            replaceLinkTag(stylePath, pluginArgs.head, replacementTag);
-            callback(null, pluginArgs);
+            // if the tagName isn't a link, do we need to do anything?
+            if(pluginArgs.head[0].tagName !== 'style') {
+              cssFilename = (cssFilename)
+                ? validatePassedCssFilename(cssFilename, compilation)
+                : identifyCssFilename(compilation);
+              const replacementTag = generateReplacementStyleTag(cssFilename, compilation);
+              const stylePath = handlePublicPath(cssFilename, compilation);
+              replaceLinkTag(stylePath, pluginArgs.head, replacementTag, compilation);
+              callback(null, pluginArgs);
+            }
+            
           } catch (err) {
             callback(err);
           }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "file-loader": "^0.9.0",
     "fs-temp": "^1.1.2",
     "html-webpack-plugin": "^2.24.1",
-    "jasmine": "2.5.2",
-    "jasmine-spec-reporter": "^2.7.0",
+    "jasmine": "2.5.3",
+    "jasmine-spec-reporter": "^3.2.0",
     "jasmine2-custom-message": "^0.8.2",
     "ncp": "^2.0.0",
     "postcss-loader": "^1.2.1",
@@ -54,7 +54,7 @@
     "url-loader": "^0.5.7"
   },
   "dependencies": {
-    "clean-css": "^3.4.23",
+    "clean-css": "^4.0.0",
     "debug": "^2.3.3",
     "webpack-sources": "^0.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-ext-html-webpack-plugin",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Enhances html-webpack-plugin functionality by enabling inline styles.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
same folder structure as before, except now with `.scss` files instead of `.css` files.

Here's my webpack.config.js for comparison:

```
var webpack = require('webpack');
var UglifyJsPlugin = webpack.optimize.UglifyJsPlugin;
var path = require('path');
var env = require('yargs').argv.mode; /* TODO: consider breaking this out into a build.js file */
var pkg = require('./package.json');
var HtmlWebpackPlugin = require('html-webpack-plugin');
var ExtractTextPlugin = require('extract-text-webpack-plugin');
var StyleExtHtmlWebpackPlugin = require('style-ext-html-webpack-plugin');
var ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');

// TODO: instead of manually adding each page name here,
//       we should crawl the folders under /pages/* and get those names
var pageNames = ['page1','page2-demo','example-page-3'];
var entry = {};
var plugins = [
  new webpack.ProvidePlugin({
    'Map': 'core-js/es6/map'
  })
];
var extractTexts = {};

// if we're building it, minify it
if (env === 'build') {
  plugins.push(new UglifyJsPlugin({ minimize: true }));
}

//////////////////////////////////////////////////////
// setup output config here
var output = {
  path: __dirname + '/dist',
  filename: '[name]-scripts.js',
  chunkFilename: '[id].bundle.js'
};

//////////////////////////////////////////////////////
// setup loaders config here
var loaders = [
  {
    test: /\.js$/,
    loader: 'babel',
    include: [
      path.resolve(__dirname, 'src', 'pages'),
      path.resolve(__dirname, 'src', 'shared', 'scripts')
    ],
    query: {
      presets: ['es2015'],
      plugins: [
        'babel-plugin-add-module-exports',
        'transform-class-properties',
        'transform-es2015-classes',
        'transform-es2015-destructuring',
        'transform-object-rest-spread'
      ]
    }
  },
  {
    test: /\.js$/,
    loader: 'eslint-loader',
    exclude: /node_modules/,
    include: [
      path.resolve(__dirname, 'src', 'pages'),
      path.resolve(__dirname, 'src', 'shared')
    ]
  },
  {
    test: /\.hbs/,
    loader: 'handlebars',
    query: {
      partialDirs: [
        path.resolve(__dirname, 'src', 'shared', 'templates')
      ],
      helperDirs: [
        path.resolve(__dirname, 'src', 'shared', 'scripts')
      ]
    }
  }/*,
  {
    test: /\.scss$/i,
    loaders: ['css-loader', 'sass-loader']
  }*/
];

// page construction happens here: we iterate through all page names we want to create,
// and extract all necessary css/js after compiling down our handlebars templates
pageNames.forEach((pageName) => {
  // setup entry object
  // TODO: see top of page; goal = crawl directory structure
  entry[pageName] = `./src/pages/${pageName}`;
  extractTexts[pageName] = new ExtractTextPlugin('[name]-styles.css');

  loaders.push({
    test: /\.scss$/i,
    loader: extractTexts[pageName].extract('style','css!sass'),
    // test: /\.scss$/,
    // loader: extractTexts[pageName].extract('style', 'css?sourceMap', 'sass?sourceMap'),
    include: [
      path.resolve(__dirname, 'src', 'pages', pageName)
    ]
  });

  plugins.push(new HtmlWebpackPlugin({
    chunks: [pageName],
    filename: `${pageName}.html`,
    template: `src/pages/${pageName}/template.hbs`
  }));

  plugins.push(extractTexts[pageName]);
});
plugins.push(new StyleExtHtmlWebpackPlugin());

plugins.push(new ScriptExtHtmlWebpackPlugin({
  inline: pageNames.map((pageName) => {
    return `${pageName}-scripts`;
  })
}));


//////////////////////////////////////////////////////
// setup webpack config
var config = {
  entry: entry,
  output: output,
  module: {
    loaders: loaders
  },
  node: {
    fs: 'empty' // necessary to avoids error messages
  },
  resolve: {
    root: path.resolve('./src'),
    extensions: ['', '.js']
  },
  plugins: plugins
};

module.exports = config;

```