### PR TITLE
Link to stylesheet not being deleted in certain cases

### DIFF
--- a/lib/replaceTag.js
+++ b/lib/replaceTag.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('./common.js');
+const path = require('path');
 const debug = common.debug;
 const extractCss = common.extractCss;
 
@@ -12,10 +13,17 @@ const generateReplacementStyleTag = (cssFilename, compilation, minifier) => {
   };
 };
 
-const handlePublicPath = (cssFilename, compilation) => {
-  const prefix = compilation.outputOptions.publicPath;
+const handlePublicPath = (cssFilename, pluginArgs, compilation) => {
+
+  var prefix = typeof compilation.options.output.publicPath !== 'undefined'
+    // If a hard coded public path exists use it
+    ? compilation.mainTemplate.getPublicPath({hash: compilation.hash})
+    // If no public path was set get a relative url path
+    : path.relative(path.resolve(compilation.options.output.path, path.dirname(pluginArgs.plugin.childCompilationOutputName)), compilation.options.output.path)
+      .split(path.sep).join('/');
+
   if (prefix) {
-    cssFilename = prefix + cssFilename;
+    cssFilename = path.join(prefix, cssFilename);
   }
   return cssFilename;
 };
@@ -44,7 +52,7 @@ const isCssLinkTag = (tagDefinition, stylePath) => {
 
 const replaceLinkTagWithStyleTag = (cssFilename, pluginArgs, compilation, minifier) => {
   const replacementTag = generateReplacementStyleTag(cssFilename, compilation, minifier);
-  const stylePath = handlePublicPath(cssFilename, compilation);
+  const stylePath = handlePublicPath(cssFilename, pluginArgs, compilation);
   replaceLinkTag(stylePath, pluginArgs.head, replacementTag);
 };
 

--- a/lib/replaceTag.js
+++ b/lib/replaceTag.js
@@ -15,7 +15,7 @@ const generateReplacementStyleTag = (cssFilename, compilation, minifier) => {
 
 const handlePublicPath = (cssFilename, pluginArgs, compilation) => {
 
-  var prefix = typeof compilation.options.output.publicPath !== 'undefined'
+  const prefix = typeof compilation.options.output.publicPath !== 'undefined'
     // If a hard coded public path exists use it
     ? compilation.mainTemplate.getPublicPath({hash: compilation.hash})
     // If no public path was set get a relative url path


### PR DESCRIPTION
Seems the issue is to do with the file path searched for. HtmlWebpackPlugin appends the public path to the asset url (e.g. ../../../) in the src when including but StyleExtWebpackPlugin doesn't use this when searching for the link tag the second time, this is why the link is appended not replaced.

Code from HtmlWebpackPlugin [here](https://github.com/jantimon/html-webpack-plugin/blob/master/index.js#L394) compared to code in the main repo [here](https://github.com/numical/style-ext-html-webpack-plugin/blob/master/lib/replaceTag.js#L16)

[Original issue](https://github.com/numical/style-ext-html-webpack-plugin/issues/29)