### PR TITLE
Fix case where publicPath is a URL

### DIFF
--- a/lib/replaceTag.js
+++ b/lib/replaceTag.js
@@ -2,6 +2,7 @@
 
 const common = require('./common.js');
 const path = require('path');
+const url = require('url');
 const debug = common.debug;
 const extractCss = common.extractCss;
 
@@ -19,8 +20,9 @@ const convertToPath = (cssFilename, pluginArgs, compilation) => {
     ? compilation.mainTemplate.getPublicPath({hash: compilation.hash})
     : path.relative(path.resolve(compilation.options.output.path, path.dirname(pluginArgs.plugin.childCompilationOutputName)), compilation.options.output.path)
       .split(path.sep).join('/');
+
   if (prefix) {
-    cssFilename = path.join(prefix, cssFilename);
+    cssFilename = url.resolve(prefix, cssFilename);
   }
 
   // hash:

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,11 +76,6 @@
         "sprintf-js": "1.0.3"
       }
     },
-    "array-buffer-from-string": {
-      "version": "https://registry.npmjs.org/array-buffer-from-string/-/array-buffer-from-string-0.1.0.tgz",
-      "integrity": "sha1-OxQ1H4YUnYTvxhLFrafthRadewc=",
-      "dev": true
-    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -141,11 +136,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
       "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-      "dev": true
-    },
-    "base32-encode": {
-      "version": "https://registry.npmjs.org/base32-encode/-/base32-encode-0.1.0.tgz",
-      "integrity": "sha1-HrxcnM+r9sJ4yGOSiLpOUO4rsfU=",
       "dev": true
     },
     "big.js": {
@@ -656,7 +646,8 @@
       }
     },
     "denodeify": {
-      "version": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
       "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
       "dev": true
     },
@@ -739,13 +730,28 @@
       }
     },
     "dynavers": {
-      "version": "https://registry.npmjs.org/dynavers/-/dynavers-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dynavers/-/dynavers-0.2.0.tgz",
       "integrity": "sha1-S8FzbGcXqyKJEif9h4rZulKrRQo=",
       "dev": true,
       "requires": {
         "rimraf": "2.6.2",
-        "rsvp": "https://registry.npmjs.org/rsvp/-/rsvp-3.4.0.tgz",
-        "spawn-cmd": "https://registry.npmjs.org/spawn-cmd/-/spawn-cmd-0.0.2.tgz"
+        "rsvp": "3.6.2",
+        "spawn-cmd": "0.0.2"
+      },
+      "dependencies": {
+        "rsvp": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+          "dev": true
+        },
+        "spawn-cmd": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/spawn-cmd/-/spawn-cmd-0.0.2.tgz",
+          "integrity": "sha1-bV4lH60OqwCw8ZPSRWaaeiKOwN4=",
+          "dev": true
+        }
       }
     },
     "electron-to-chromium": {
@@ -1253,14 +1259,6 @@
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
-    "fmix": {
-      "version": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
-      "integrity": "sha1-x7vxJN7ELJ0ZHPuUfQqXeN2YbAw=",
-      "dev": true,
-      "requires": {
-        "imul": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz"
-      }
-    },
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
@@ -1268,11 +1266,62 @@
       "dev": true
     },
     "fs-temp": {
-      "version": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.1.2.tgz",
       "integrity": "sha1-zFLwOLvv5RD2vNCexZK3nQ9pJT8=",
       "dev": true,
       "requires": {
-        "random-path": "https://registry.npmjs.org/random-path/-/random-path-0.1.1.tgz"
+        "random-path": "0.1.1"
+      },
+      "dependencies": {
+        "array-buffer-from-string": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/array-buffer-from-string/-/array-buffer-from-string-0.1.0.tgz",
+          "integrity": "sha1-OxQ1H4YUnYTvxhLFrafthRadewc=",
+          "dev": true
+        },
+        "base32-encode": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-0.1.1.tgz",
+          "integrity": "sha512-jjc+6TC8PXrsxJ4CQr9ibioNhhAM1p/RvS9hy3Q+cxPphvXmLnFSkXoen2XXzNBrYjdmzajRtbFDl1x28F5F4A==",
+          "dev": true
+        },
+        "fmix": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
+          "integrity": "sha1-x7vxJN7ELJ0ZHPuUfQqXeN2YbAw=",
+          "dev": true,
+          "requires": {
+            "imul": "1.0.1"
+          }
+        },
+        "imul": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
+          "integrity": "sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk=",
+          "dev": true
+        },
+        "murmur-32": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.1.0.tgz",
+          "integrity": "sha1-waedT8X6vwQFdJ0K/3fEFAIFWGE=",
+          "dev": true,
+          "requires": {
+            "array-buffer-from-string": "0.1.0",
+            "fmix": "0.1.0",
+            "imul": "1.0.1"
+          }
+        },
+        "random-path": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.1.tgz",
+          "integrity": "sha1-+PTTb3WhNMoV/TnH11BfvxY7Y0w=",
+          "dev": true,
+          "requires": {
+            "base32-encode": "0.1.1",
+            "murmur-32": "0.1.0"
+          }
+        }
       }
     },
     "fs.realpath": {
@@ -1522,11 +1571,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
       "integrity": "sha512-HrxmNxKTGZ9a3uAl/FNG66Sdt0G9L4TtMbbUQjP1WhGmSj0FOyHvSgx7623aGJvXfPOur8MwmarlHT+37jmzlw==",
-      "dev": true
-    },
-    "imul": {
-      "version": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
-      "integrity": "sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk=",
       "dev": true
     },
     "imurmurhash": {
@@ -1942,16 +1986,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "murmur-32": {
-      "version": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.1.0.tgz",
-      "integrity": "sha1-waedT8X6vwQFdJ0K/3fEFAIFWGE=",
-      "dev": true,
-      "requires": {
-        "array-buffer-from-string": "https://registry.npmjs.org/array-buffer-from-string/-/array-buffer-from-string-0.1.0.tgz",
-        "fmix": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
-        "imul": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz"
-      }
-    },
     "mute-stream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
@@ -1974,7 +2008,8 @@
       }
     },
     "ncp": {
-      "version": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "dev": true
     },
@@ -2840,11 +2875,110 @@
       }
     },
     "postcss-spiffing": {
-      "version": "https://registry.npmjs.org/postcss-spiffing/-/postcss-spiffing-0.1.0.tgz",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-spiffing/-/postcss-spiffing-0.1.0.tgz",
       "integrity": "sha1-JRsiqXmYy0/vYFGa2Z5/RnHS8lI=",
       "dev": true,
       "requires": {
-        "postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+        "postcss": "5.2.18"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "js-base64": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
+          "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
+          "dev": true
+        },
+        "postcss": {
+          "version": "5.2.18",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "js-base64": "2.4.0",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
       }
     },
     "postcss-svgo": {
@@ -2935,15 +3069,6 @@
       "requires": {
         "object-assign": "4.1.1",
         "strict-uri-encode": "1.1.0"
-      }
-    },
-    "random-path": {
-      "version": "https://registry.npmjs.org/random-path/-/random-path-0.1.1.tgz",
-      "integrity": "sha1-+PTTb3WhNMoV/TnH11BfvxY7Y0w=",
-      "dev": true,
-      "requires": {
-        "base32-encode": "https://registry.npmjs.org/base32-encode/-/base32-encode-0.1.0.tgz",
-        "murmur-32": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.1.0.tgz"
       }
     },
     "readable-stream": {
@@ -3107,11 +3232,6 @@
         "glob": "7.1.2"
       }
     },
-    "rsvp": {
-      "version": "https://registry.npmjs.org/rsvp/-/rsvp-3.4.0.tgz",
-      "integrity": "sha1-lvOX2cfilDUbPBRWp0s9DnVCmI0=",
-      "dev": true
-    },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
@@ -3232,11 +3352,6 @@
     "source-map": {
       "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
-    },
-    "spawn-cmd": {
-      "version": "https://registry.npmjs.org/spawn-cmd/-/spawn-cmd-0.0.2.tgz",
-      "integrity": "sha1-bV4lH60OqwCw8ZPSRWaaeiKOwN4=",
-      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/spec/helpers/main-tests.js
+++ b/spec/helpers/main-tests.js
@@ -301,9 +301,34 @@ const mainTests = (baseConfig, baseExpectations, multiEntryConfig, multiEntryExp
     testPlugin(config, expected, done);
   });
 
+  it('copes with a URL public path', done => {
+    const config = baseConfig('one_stylesheet');
+    config.output.publicPath = 'https://www.github.com/wibble/';
+    const expected = baseExpectations();
+    expected.html = [
+      /<style>[\s\S]*background: snow;[\s\S]*<\/style>/
+    ];
+    testPlugin(config, expected, done);
+  });
+
   it('copes with a public path with specified css file', done => {
     const config = baseConfig('one_stylesheet');
     config.output.publicPath = '/wibble/';
+    config.plugins = [
+      new HtmlWebpackPlugin(),
+      new ExtractTextPlugin('styles.css'),
+      new StyleExtHtmlWebpackPlugin('styles.css')
+    ];
+    const expected = baseExpectations();
+    expected.html = [
+      /<style>[\s\S]*background: snow;[\s\S]*<\/style>/
+    ];
+    testPlugin(config, expected, done);
+  });
+
+  it('copes with a URL public path with specified css file', done => {
+    const config = baseConfig('one_stylesheet');
+    config.output.publicPath = 'https://www.github.com/wibble/';
     config.plugins = [
       new HtmlWebpackPlugin(),
       new ExtractTextPlugin('styles.css'),


### PR DESCRIPTION
Fixes #33 

Not sure if others have experienced the exact same issue as me, but this "works on my machine".

To clarify; this part in `replaceTag.js`

```js
if (prefix) {
  cssFilename = path.join(prefix, cssFilename);
}
```

Would change a `publicPath` containing a URL from this:

```
https://www.example.com/somepath/critical.css
```

To this (note the missing slash following the protocol):

```
https:/www.example.com/somepath/critical.css
```