### PR TITLE
Quickfix to make it webpack 4 compatible

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -11,12 +11,12 @@ const insertStyleTagInHtml = require('./insertStyle.js');
 const deleteFileFromCompilation = require('./removeFile.js');
 
 const wirePluginEvent = (event, compilation, fn) => {
-  compilation.plugin(event, (pluginArgs, callback) => {
+  compilation.plugin(event, (pluginArgs) => {
     try {
       fn(pluginArgs);
-      callback(null, pluginArgs);
+      return pluginArgs;
     } catch (err) {
-      callback(err);
+      return new Error(err);
     }
   });
 };


### PR DESCRIPTION
This would break compatibility with older webpack versions, and someone should probably check if there is something else. So don't merge this like it is.

But this is good enough to make it work with webpack 4. If someone else needs it.
